### PR TITLE
Add missing asm dependency to xtend-gradle-lib

### DIFF
--- a/xtend-gradle-lib/build.gradle
+++ b/xtend-gradle-lib/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   compile 'org.eclipse.xtend:org.eclipse.xtend.core:2.5.+'
   compile 'com.martiansoftware:nailgun-server:0.9.1'
+  compile 'asm:asm-commons:3.3.1'
 }
 
 uploadArchives.repositories.mavenDeployer.pom.project {


### PR DESCRIPTION
`ClassFileDebugSourceExtractor` imports `org.objectweb.asm.commons.EmptyVisitor`, which comes from asm-commons.
